### PR TITLE
Fix farmer trade

### DIFF
--- a/common/src/main/resources/data/minecraft/moonlight/villager_trade/farmer/kernels.json
+++ b/common/src/main/resources/data/minecraft/moonlight/villager_trade/farmer/kernels.json
@@ -15,11 +15,11 @@
   "max_trades": 12,
   "offer": {
     "id": "minecraft:emerald",
-    "Count": 1
+    "count": 1
   },
   "price": {
     "id": "hauntedharvest:kernels",
-    "Count": 20
+    "count": 20
   },
   "level": 1
 }


### PR DESCRIPTION
Fixes issue where farmers were buying kernels at 1 kernel per emerald instead of 20